### PR TITLE
Add endpoint to create a device

### DIFF
--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesController.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -26,9 +27,9 @@ public class DevicesController {
     }
 
     @PostMapping
-    public ResponseEntity<Device> addDevice(@RequestBody Device device) {
+    @ResponseStatus(HttpStatus.CREATED)
+    public Device addDevice(@RequestBody Device device) {
         var newDevice = new Device(device.getId());
-        repository.save(newDevice);
-        return new ResponseEntity<>(newDevice, HttpStatus.CREATED);
+        return repository.save(newDevice);
     }
 }


### PR DESCRIPTION
Adds functionality to add a new device in the devices-api app.

I tested this locally with docker:
1. Set up the CosmosDB account with bicep
2. Run the devices-api module with docker
3.  Send a POST request to `http://localhost:8080/devices` with the following payload:

e.g.
```
{
    "id": "123456"
}
```

4. The new device is visible in Cosmos and in the reponse of `GetDevices` endpoint.