### PR TITLE
Make the java image smaller

### DIFF
--- a/sample-application/devices-api/Dockerfile
+++ b/sample-application/devices-api/Dockerfile
@@ -1,12 +1,15 @@
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as builder
 
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
 
+RUN ./gradlew build
+
+FROM eclipse-temurin:17
+COPY --from=builder /app/build/libs/devices-api.jar /app
+
 # Download opentelemetry-javaagent.jar
 RUN curl -L -O https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar
-
-RUN ./gradlew build
 
 ENTRYPOINT ["java", "-javaagent:opentelemetry-javaagent.jar", "-jar","build/libs/devices-api.jar"]

--- a/sample-application/devices-api/Dockerfile
+++ b/sample-application/devices-api/Dockerfile
@@ -7,9 +7,10 @@ WORKDIR /app
 RUN ./gradlew build
 
 FROM eclipse-temurin:17
+WORKDIR /app
 COPY --from=builder /app/build/libs/devices-api.jar /app
 
 # Download opentelemetry-javaagent.jar
 RUN curl -L -O https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar
 
-ENTRYPOINT ["java", "-javaagent:opentelemetry-javaagent.jar", "-jar","build/libs/devices-api.jar"]
+ENTRYPOINT ["java", "-javaagent:opentelemetry-javaagent.jar", "-jar","devices-api.jar"]


### PR DESCRIPTION
Use multi stage docker to make the image smaller.

With this change the size decreases from 968MB to 467MB. I didn't really notice any significant improvement with the build time.


## Notes
I was trying to make it even smaller (~130MB), but still get some issues, the image is not build correctly and the app doesn't start. If you are interested, my WIP changes are on branch **ik/109/smaller-java-image**.

closes #109 