### PR TITLE
Add a new java service that simulates long running job 

### DIFF
--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesApiApplication.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesApiApplication.java
@@ -4,12 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableSwagger2
 public class DevicesApiApplication {
 
@@ -20,9 +22,10 @@ public class DevicesApiApplication {
 			e.printStackTrace();
 		}
 	}
-  @Bean
-   public Docket productApi() {
+
+    @Bean
+   	public Docket productApi() {
       return new Docket(DocumentationType.SWAGGER_2).select()
          .apis(RequestHandlerSelectors.basePackage("observabilitylab.devices")).build();
-   }
+   	}
 }

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesController.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/DevicesController.java
@@ -2,6 +2,7 @@ package observabilitylab.devices;
 
 import java.util.List;
 import observabilitylab.devices.model.Device;
+import observabilitylab.devices.model.DeviceJob;
 import observabilitylab.devices.model.UpdateDevice;
 
 import org.slf4j.Logger;
@@ -28,6 +29,8 @@ public class DevicesController {
 
     @Autowired
     private DevicesRepository repository;
+    @Autowired
+    private JobsRepository jobsRepository;
 
     @GetMapping
     public ResponseEntity<List<Device>> getDevices() {
@@ -104,6 +107,31 @@ public class DevicesController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Device with id %s not found".formatted(id));
         }
         repository.deleteDeviceById(id);
+    }
+
+    @PostMapping("/jobs")
+    @ResponseStatus(HttpStatus.CREATED)
+    public String createJob(@RequestBody String deviceId) {
+        logger.info("Create job for device with id %s".formatted(deviceId));
+        Device device = repository.getDeviceById(deviceId);
+        if (device == null) {
+            logger.warn("Device with id %s not found".formatted(deviceId));
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Device with id %s not found".formatted(deviceId));
+        }
+        DeviceJob deviceJob = jobsRepository.save(new DeviceJob(deviceId));
+        return deviceJob.getId();
+    }
+
+    @GetMapping("/jobs/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public DeviceJob getJobById(@PathVariable("id") String id) {
+        logger.info("GET job with id %s".formatted(id));
+        DeviceJob deviceJob = jobsRepository.getDeviceJobById(id);
+        if (deviceJob == null) {
+            logger.warn("Job with id %s not found".formatted(id));
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Job with id %s not found".formatted(id));
+        }
+        return deviceJob;
     }
 
 }

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Component
@@ -20,7 +19,7 @@ public class JobService {
 
     @Scheduled(fixedRate = 60000) // Execute every 60 seconds
     public void executeJob() {
-        repository.findAll().forEach(job -> {
+        repository.findAll().stream().filter(job -> DeviceJob.JobStatus.IN_PROGRESS.equals(job.getStatus())).forEach(job -> {
             Executors.newSingleThreadExecutor().submit(() -> {
                 try {
                     job.setStatus(DeviceJob.JobStatus.IN_PROGRESS);

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
@@ -19,7 +19,7 @@ public class JobService {
 
     @Scheduled(fixedRate = 60000) // Execute every 60 seconds
     public void executeJob() {
-        repository.findAll().stream().filter(job -> DeviceJob.JobStatus.IN_PROGRESS.equals(job.getStatus())).forEach(job -> {
+        repository.findAll().stream().filter(job -> DeviceJob.JobStatus.NEW.equals(job.getStatus())).forEach(job -> {
             Executors.newSingleThreadExecutor().submit(() -> {
                 try {
                     job.setStatus(DeviceJob.JobStatus.IN_PROGRESS);

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/JobService.java
@@ -1,0 +1,43 @@
+package observabilitylab.devices;
+
+import observabilitylab.devices.model.DeviceJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Component
+public class JobService {
+
+    private Logger logger = LoggerFactory.getLogger(JobService.class);
+
+    @Autowired
+    private JobsRepository repository;
+
+    @Scheduled(fixedRate = 60000) // Execute every 60 seconds
+    public void executeJob() {
+        repository.findAll().forEach(job -> {
+            Executors.newSingleThreadExecutor().submit(() -> {
+                try {
+                    job.setStatus(DeviceJob.JobStatus.IN_PROGRESS);
+                    repository.save(job);
+                    // Simulate a long-running task
+                    Thread.sleep(60000);
+                    logger.info("Task completed for job: " + job.getId());
+                    job.setStatus(DeviceJob.JobStatus.COMPLETED);
+                    repository.save(job);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.error("Task was interrupted");
+                    job.setStatus(DeviceJob.JobStatus.FAILED);
+                    repository.save(job);
+                }
+            });
+            logger.info("Executed job: " + job.getId() + " for device: " + job.getDeviceId());
+        });
+    }
+}

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/JobsRepository.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/JobsRepository.java
@@ -1,0 +1,16 @@
+package observabilitylab.devices;
+
+import com.azure.spring.data.cosmos.repository.CosmosRepository;
+import observabilitylab.devices.model.DeviceJob;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface JobsRepository extends CosmosRepository<DeviceJob, String> {
+
+    List<DeviceJob> findAll();
+    DeviceJob getDeviceJobById(String id);
+    void deleteDeviceJobById(String id);
+    DeviceJob save(DeviceJob job);
+}

--- a/sample-application/devices-api/src/main/java/observabilitylab/devices/model/DeviceJob.java
+++ b/sample-application/devices-api/src/main/java/observabilitylab/devices/model/DeviceJob.java
@@ -1,0 +1,59 @@
+package observabilitylab.devices.model;
+
+import com.azure.spring.data.cosmos.core.mapping.Container;
+import com.azure.spring.data.cosmos.core.mapping.GeneratedValue;
+import com.azure.spring.data.cosmos.core.mapping.PartitionKey;
+import org.springframework.data.annotation.Id;
+
+
+@Container(containerName = "jobsContainer", ru = "400")
+public class DeviceJob {
+
+    @GeneratedValue
+    @Id
+    @PartitionKey
+    private String id;
+
+    private String deviceId;
+    private String status;
+
+
+    public DeviceJob(String deviceId) {
+        this.deviceId = deviceId;
+        this.status = JobStatus.NEW;
+    }
+
+    public DeviceJob(String id, String deviceId, String status) {
+        this.id = id;
+        this.deviceId = deviceId;
+        this.status = status;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public String toString() {
+        return "Device [id=" + id + ", deviceId=" + deviceId + "]";
+    }
+
+    public class JobStatus {
+        public static final String NEW = "NEW";
+        public static final String IN_PROGRESS = "IN_PROGRESS";
+        public static final String COMPLETED = "COMPLETED";
+        public static final String FAILED = "FAILED";
+    }
+}


### PR DESCRIPTION
New Java service withing devices-api that simulates a long running job. 
The user can submit jobs using API endpoint, the endpoint returns a job id that can be sued to poll the status of the job. 
The jobs are saved in Cosmos database.

The service will be used to demonstrate custom traces in Java. (In the next PRs)