### PR TITLE
Fix for Bicep binary architecture on aarch64

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,5 +36,5 @@
             ]
         }
     },
-      "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
+      "postCreateCommand": "/bin/bash .devcontainer/postCreateCommand.sh"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,2 +1,13 @@
+#!/bin/bash
+set -eu
+
+# Create Python virtual environment
 cd sample-application/device-assistant/
 poetry install
+
+# Azure CLI download the Bicep binary in the wrong architecture on linux/arm64.
+# See Azure/azure-cli#29435
+if [ "$(arch)" == "aarch64" ];then
+  az bicep uninstall
+  az bicep install --target-platform linux-arm64
+fi


### PR DESCRIPTION
Workaround for Azure/azure-cli#29435 which causes download of the bicep binary with incorrect architecture on aarch64 images.
