### PR TITLE
Remove building no-auto-instrumentation image

### DIFF
--- a/sample-application/sample.sh
+++ b/sample-application/sample.sh
@@ -14,8 +14,6 @@ build_images() {
     cd ../devices-state-manager/DevicesStateManager || { echo "Directory not found" && exit "2"; }
     echo "Image Tag: $DEVICE_MANAGER_IMAGE_NAME:$TAG"
     docker build -t "$DEVICE_MANAGER_IMAGE_NAME":"$TAG" .
-    echo "Image Tag: $DEVICE_MANAGER_IMAGE_NAME:no-auto-instrumentation"
-    docker build -f Dockerfile.no-auto-instrumentation -t "$DEVICE_MANAGER_IMAGE_NAME":no-auto-instrumentation .
     echo ""
     cd ../../..
 }
@@ -29,8 +27,6 @@ push_images(){
     docker push "$ACR_NAME".azurecr.io/"$DEVICE_API_IMAGE_NAME":"$TAG"
     docker tag "$DEVICE_MANAGER_IMAGE_NAME":"$TAG" "$ACR_NAME".azurecr.io/"$DEVICE_MANAGER_IMAGE_NAME":"$TAG"
     docker push "$ACR_NAME".azurecr.io/"$DEVICE_MANAGER_IMAGE_NAME":"$TAG"
-    docker tag "$DEVICE_MANAGER_IMAGE_NAME":no-auto-instrumentation "$ACR_NAME".azurecr.io/"$DEVICE_MANAGER_IMAGE_NAME":no-auto-instrumentation
-    docker push "$ACR_NAME".azurecr.io/"$DEVICE_MANAGER_IMAGE_NAME":no-auto-instrumentation
     echo ""
 }
 


### PR DESCRIPTION
building no-auto-instrumentation image for DevicesStateManager causes printing error messages. Let's remove it until we decide what we want to do with the otel-operator (#209 )